### PR TITLE
Update the color picker

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -71,7 +71,7 @@
         placeholder="username"
       />
       <input
-        class="h-12"
+        class="h-12 color-picker"
         style="padding: 0.25em !important"
         type="color"
         bind:value={usernameColor}
@@ -86,7 +86,7 @@
 
     <section class="message-input flex flex-row gap-1">
       <input
-        class="grow h-12"
+        class="grow h-12 "
         type="text"
         bind:value={message}
         placeholder="message"
@@ -144,5 +144,9 @@
 
   button.icon-button {
     @apply border-2 rounded-lg p-2;
+  }
+
+  .color-picker {
+    background-color: #36393f;
   }
 </style>


### PR DESCRIPTION
# Issue
Since the color picker is white at the beginning, it's quite difficult to notice.

I'm trying to add more visual clue by giving it a background color.

Please consider this change.

## Before
![image](https://user-images.githubusercontent.com/28824919/193312547-a3c42c53-125b-4088-b5b7-b1cba3a43bf0.png)

## After
![image](https://user-images.githubusercontent.com/28824919/193312572-90a79cf1-3b50-49dc-b9f0-290fd771974e.png)
